### PR TITLE
Bump versions for Matter 1.3

### DIFF
--- a/scripts/install_sdk.sh
+++ b/scripts/install_sdk.sh
@@ -30,7 +30,7 @@ cd ${sdk_path}
 git clone --recursive https://github.com/espressif/esp-idf.git esp-idf
 cd ${esp_idf_path}
 git fetch --all --tags
-git checkout 6b1f40b9bfb91ec82fab4a60e5bfb4ca0c9b062f
+git checkout v5.2.1
 git submodule update --init --recursive
 bash ./install.sh
 

--- a/scripts/install_sdk.sh
+++ b/scripts/install_sdk.sh
@@ -34,10 +34,12 @@ git checkout v5.2.1
 git submodule update --init --recursive
 bash ./install.sh
 
-# clone esp-matter repository and install connectedhomeip submodules      
+# clone esp-matter repository and install connectedhomeip submodules
 cd ${sdk_path}
 git clone --depth 1 https://github.com/espressif/esp-matter.git esp-matter
 cd ${esp_matter_path}
+git fetch --all --tags
+git checkout release/v1.3
 git submodule update --init --depth 1
 cd ./connectedhomeip/connectedhomeip
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Bump versions for Matter 1.3:
- esp-matter supported Branch for Matter 1.3 is 'release/v1.3'
- For Matter projects development with this SDK, it is recommended to utilize ESP-IDF v5.2.1.
